### PR TITLE
fix(generator): change order of cleanup of the overrides

### DIFF
--- a/scripts/generateWrappers/consts.js
+++ b/scripts/generateWrappers/consts.js
@@ -335,6 +335,12 @@ const Vivid3ComponentsExtraPropertiesMap = {
       name: 'value',
       type: { text: 'string' }
     }
+  ],
+  DataGridCell: [
+    {
+      name: 'ariaSelected',
+      type: { text: 'boolean | undefined' }
+    }
   ]
 }
 

--- a/scripts/generateWrappers/generator.js
+++ b/scripts/generateWrappers/generator.js
@@ -72,7 +72,7 @@ const renderComponent = tag => language => componentName => {
 
 const removeDuplicates = (arr) => {
   const seen = new Set();
-  return arr.filter(item => {
+  return arr.toReversed().filter(item => {
     if (seen.has(item.name)) {
       return false;
     } else {


### PR DESCRIPTION
 change order of cleanup of the overrides to avoid to remove overrides.
 Extra props and overrides are concat to list of props, originally duplicates are removed. but in this way if overrides are declared it will remove the override.
 

fix ariaSelected attribute on DataGridCell not compliant to specs 
specs says `boolean`, but TS infers `string | null | undefined` https://vivid.deno.dev/components/data-grid/#cell 

